### PR TITLE
Update to new ldap.v3 path

### DIFF
--- a/ldap-client.go
+++ b/ldap-client.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/ldap.v3"
+	"github.com/go-ldap/ldap/v3"
 )
 
 type LDAPClient struct {


### PR DESCRIPTION
```
go: downloading gopkg.in/ldap.v3 v3.1.3
go get: gopkg.in/ldap.v3@v3.1.3: parsing go.mod:
	module declares its path as: github.com/go-ldap/ldap/v3
	       but was required as: gopkg.in/ldap.v3
```